### PR TITLE
Add missing include

### DIFF
--- a/include/boost/type_erasure/detail/storage.hpp
+++ b/include/boost/type_erasure/detail/storage.hpp
@@ -14,6 +14,7 @@
 #include <boost/config.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_cv.hpp>
+#include <utility>
 
 #ifdef BOOST_MSVC
 #pragma warning(push)


### PR DESCRIPTION
This header uses std::forward, but doesn't include the header that defines it - issue exposed by ongoing type traits rewrite.