### PR TITLE
Moved "use_default" from namespace "boost" into "boost/type_erasure".

### DIFF
--- a/include/boost/type_erasure/is_placeholder.hpp
+++ b/include/boost/type_erasure/is_placeholder.hpp
@@ -16,11 +16,10 @@
 #include <boost/type_erasure/placeholder.hpp>
 
 namespace boost {
+namespace type_erasure {
 
 /** INTERNAL ONLY */
 struct use_default;
-
-namespace type_erasure {
 
 /** A metafunction that indicates whether a type is a @ref placeholder. */
 template<class T>
@@ -28,7 +27,7 @@ struct is_placeholder : ::boost::is_base_and_derived<placeholder, T> {};
 
 /** INTERNAL ONLY */
 template<>
-struct is_placeholder< ::boost::use_default> : ::boost::mpl::false_ {};
+struct is_placeholder< ::boost::type_erasure::use_default> : ::boost::mpl::false_ {};
 
 }
 }

--- a/include/boost/type_erasure/iterator.hpp
+++ b/include/boost/type_erasure/iterator.hpp
@@ -24,9 +24,9 @@
 
 namespace boost {
 
-struct use_default;
-
 namespace type_erasure {
+
+struct use_default;
 
 namespace detail {
 
@@ -52,7 +52,7 @@ struct iterator_value_type
 template<
     class Traversal,
     class T = _self,
-    class Reference = ::boost::use_default,
+    class Reference = ::boost::type_erasure::use_default,
     class DifferenceType = ::std::ptrdiff_t,
     class ValueType = typename deduced<iterator_value_type<T> >::type
 >
@@ -67,7 +67,7 @@ struct iterator;
  *         @c boost::single_pass_traversal_tag, @c boost::forward_traversal_tag,
  *         @c boost::bidirectional_traversal_tag, and @c boost::random_access_traversal_tag.
  * \tparam T The placeholder representing the iterator.
- * \tparam Reference The reference type.  If it is boost::use_default, then
+ * \tparam Reference The reference type.  If it is boost::type_erasure::use_default, then
  *         reference will be value_type&.
  * \tparam DifferenceType The iterator's difference type.
  *
@@ -85,7 +85,7 @@ struct iterator;
 template<
     class Traversal,
     class T = _self,
-    class Reference = boost::use_default,
+    class Reference = boost::type_erasure::use_default,
     class DifferenceType = std::ptrdiff_t
 >
 struct iterator
@@ -97,7 +97,7 @@ struct iterator
 
 template<
     class T = _self,
-    class Reference = boost::use_default,
+    class Reference = boost::type_erasure::use_default,
     class DifferenceType = std::ptrdiff_t
 >
 struct forward_iterator :
@@ -106,7 +106,7 @@ struct forward_iterator :
 
 template<
     class T = _self,
-    class Reference = boost::use_default,
+    class Reference = boost::type_erasure::use_default,
     class DifferenceType = std::ptrdiff_t
 >
 struct bidirectional_iterator :
@@ -115,7 +115,7 @@ struct bidirectional_iterator :
 
 template<
     class T = _self,
-    class Reference = boost::use_default,
+    class Reference = boost::type_erasure::use_default,
     class DifferenceType = std::ptrdiff_t
 >
 struct random_access_iterator :
@@ -134,7 +134,7 @@ struct iterator_reference
 
 /** INTERNAL ONLY */
 template<class ValueType>
-struct iterator_reference< ::boost::use_default, ValueType>
+struct iterator_reference< ::boost::type_erasure::use_default, ValueType>
 {
     typedef ValueType& type;
 };
@@ -206,7 +206,7 @@ struct iterator< ::boost::random_access_traversal_tag, T, Reference, DifferenceT
 
 template<
     class T = _self,
-    class Reference = ::boost::use_default,
+    class Reference = ::boost::type_erasure::use_default,
     class DifferenceType = ::std::ptrdiff_t,
     class ValueType = typename deduced<iterator_value_type<T> >::type
 >
@@ -216,7 +216,7 @@ struct forward_iterator :
 
 template<
     class T = _self,
-    class Reference = ::boost::use_default,
+    class Reference = ::boost::type_erasure::use_default,
     class DifferenceType = ::std::ptrdiff_t,
     class ValueType = typename deduced<iterator_value_type<T> >::type
 >
@@ -226,7 +226,7 @@ struct bidirectional_iterator :
 
 template<
     class T = _self,
-    class Reference = ::boost::use_default,
+    class Reference = ::boost::type_erasure::use_default,
     class DifferenceType = ::std::ptrdiff_t,
     class ValueType = typename deduced<iterator_value_type<T> >::type
 >


### PR DESCRIPTION
This fixes compiler-errors ("conflicting declaration") which would occur if included in the same translation-unit as "boost/iterator/iterator_adaptor.hpp".

The clash with the original code would occur for the following simple code, for example:
```
#include <boost/type_erasure/iterator.hpp>
#include <boost/iterator/iterator_adaptor.hpp>
```
Both, GCC and Clang fail to compile this, but Clang is more verbose:

    /tmp/boost-1_58/boost/iterator/iterator_adaptor.hpp:44:18: error: target of using declaration conflicts with declaration already in scope
    using iterators::use_default;
                     ^
    /tmp/boost-1_58/boost/iterator/iterator_adaptor.hpp:40:10: note: target of using declaration
      struct use_default;
             ^
    /tmp/boost-1_58/boost/type_erasure/iterator.hpp:27:8: note: conflicting declaration
    struct use_default;
           ^
    1 error generated.

I originally provided a patch against _Boost.Iterator_, however, I [got told](https://github.com/boostorg/iterator/pull/15#issuecomment-122029643) that patch should be applied to _Boost.Type_Erasure_ instead.