### PR TITLE
Fix test compile break

### DIFF
--- a/test/test_dynamic_any_cast.cpp
+++ b/test/test_dynamic_any_cast.cpp
@@ -37,7 +37,7 @@ struct fixture
     }
 };
 
-BOOST_GLOBAL_FIXTURE(fixture)
+BOOST_GLOBAL_FIXTURE(fixture);
 
 BOOST_AUTO_TEST_CASE(test_identical)
 {


### PR DESCRIPTION
After https://github.com/boostorg/test/commit/3f7216db3db2e11a768d8d0c8bb18632f106c466, BOOST_GLOBAL_FIXTURE has to be followed by a semicolon.