### PR TITLE
Fix construction of any from static_binding.

### DIFF
--- a/include/boost/type_erasure/any.hpp
+++ b/include/boost/type_erasure/any.hpp
@@ -871,7 +871,6 @@ public:
     {}
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-
     explicit any(binding<Concept>&& binding_arg)
       : table(binding_arg),
         data(
@@ -881,7 +880,40 @@ public:
             )
         )
     {}
+#endif
 
+    template<class Map>
+    explicit any(const static_binding<Map>& binding_arg)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::constructible<T()>()
+            )
+        )
+    {}
+    template<class Map>
+    explicit any(static_binding<Map>& binding_arg)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::constructible<T()>()
+            )
+        )
+    {}
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    template<class Map>
+    explicit any(static_binding<Map>&& binding_arg)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::constructible<T()>()
+            )
+        )
+    {}
 #endif
 
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
@@ -946,6 +978,48 @@ public:
         data(
             ::boost::type_erasure::call(
                 binding_arg,
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(std::forward<U0>(u0), std::forward<U>(u)...) : 0
+                ),
+                std::forward<U0>(u0), std::forward<U>(u)...
+            )
+        )
+    {}
+
+    template<class Map, class U0, class... U>
+    any(const static_binding<Map>& binding_arg, U0&& u0, U&&... u)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(std::forward<U0>(u0), std::forward<U>(u)...) : 0
+                ),
+                std::forward<U0>(u0), std::forward<U>(u)...
+            )
+        )
+    {}
+
+    // disambiguate
+    template<class Map, class U0, class... U>
+    any(static_binding<Map>& binding_arg, U0&& u0, U&&... u)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(std::forward<U0>(u0), std::forward<U>(u)...) : 0
+                ),
+                std::forward<U0>(u0), std::forward<U>(u)...
+            )
+        )
+    {}
+    template<class Map, class U0, class... U>
+    any(static_binding<Map>&& binding_arg, U0&& u0, U&&... u)
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
                 ::boost::type_erasure::detail::make(
                     false? this->_boost_type_erasure_deduce_constructor(std::forward<U0>(u0), std::forward<U>(u)...) : 0
                 ),

--- a/include/boost/type_erasure/check_match.hpp
+++ b/include/boost/type_erasure/check_match.hpp
@@ -100,6 +100,14 @@ bool check_table(const ::boost::type_erasure::binding<Concept>* /*t*/, void(*)()
     return true;
 }
 
+template<class Concept, class R>
+bool check_table(
+    const ::boost::type_erasure::binding<Concept>* t,
+    R(*)())
+{
+    return check_table(t, static_cast<void(*)()>(0));
+}
+
 template<class Concept, class R, class T0, class... T, class U0, class... U>
 bool check_table(
     const ::boost::type_erasure::binding<Concept>* t,

--- a/include/boost/type_erasure/detail/construct.hpp
+++ b/include/boost/type_erasure/detail/construct.hpp
@@ -108,6 +108,53 @@
         )
     {}
 
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(const static_binding<Map>& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, U, &&u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_TYPE_ERASURE_FORWARD(N)) : 0
+                )
+                BOOST_PP_COMMA_IF(N)
+                BOOST_TYPE_ERASURE_FORWARD(N)
+            )
+        )
+    {}
+
+    // disambiguate
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(static_binding<Map>& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, U, &&u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_TYPE_ERASURE_FORWARD(N)) : 0
+                )
+                BOOST_PP_COMMA_IF(N)
+                BOOST_TYPE_ERASURE_FORWARD(N)
+            )
+        )
+    {}
+
+    // disambiguate
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(static_binding<Map>&& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, U, &&u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_TYPE_ERASURE_FORWARD(N)) : 0
+                )
+                BOOST_PP_COMMA_IF(N)
+                BOOST_TYPE_ERASURE_FORWARD(N)
+            )
+        )
+    {}
+
 #undef BOOST_TYPE_ERASURE_FORWARD
 #undef BOOST_TYPE_ERASURE_FORWARD_I
 
@@ -196,6 +243,49 @@
         data(
             ::boost::type_erasure::call(
                 binding_arg,
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_PP_ENUM_PARAMS(N, u)) : 0
+                )
+                BOOST_PP_ENUM_TRAILING_PARAMS(N, u)
+            )
+        )
+    {}
+
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(const static_binding<Map>& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, const U, &u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_PP_ENUM_PARAMS(N, u)) : 0
+                )
+                BOOST_PP_ENUM_TRAILING_PARAMS(N, u)
+            )
+        )
+    {}
+
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(const static_binding<Map>& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, U, &u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
+                ::boost::type_erasure::detail::make(
+                    false? this->_boost_type_erasure_deduce_constructor(BOOST_PP_ENUM_PARAMS(N, u)) : 0
+                )
+                BOOST_PP_ENUM_TRAILING_PARAMS(N, u)
+            )
+        )
+    {}
+
+    // disambiguate
+    template<class Map, BOOST_PP_ENUM_PARAMS(N, class U)>
+    any(static_binding<Map>& binding_arg BOOST_PP_ENUM_TRAILING_BINARY_PARAMS(N, U, &u))
+      : table(binding_arg),
+        data(
+            ::boost::type_erasure::call(
+                ::boost::type_erasure::binding<Concept>(binding_arg),
                 ::boost::type_erasure::detail::make(
                     false? this->_boost_type_erasure_deduce_constructor(BOOST_PP_ENUM_PARAMS(N, u)) : 0
                 )

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -43,6 +43,8 @@ compile test_param.cpp ;
 compile test_is_subconcept.cpp ;
 
 compile-fail fail_default_construct.cpp ;
+compile-fail fail_default_construct_from_binding.cpp ;
+compile-fail fail_default_construct_from_binding_of.cpp ;
 compile-fail fail_construct_mismatch.cpp ;
 compile-fail fail_construct_mismatch_ref.cpp ;
 compile-fail fail_construct_mismatch_cref.cpp ;

--- a/test/fail_default_construct_from_binding.cpp
+++ b/test/fail_default_construct_from_binding.cpp
@@ -1,0 +1,23 @@
+// Boost.TypeErasure library
+//
+// Copyright 2011 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// $Id$
+
+#include <boost/type_erasure/any.hpp>
+#include <boost/type_erasure/binding.hpp>
+#include <boost/type_erasure/builtin.hpp>
+#include <boost/mpl/map.hpp>
+#include <boost/mpl/pair.hpp>
+
+using namespace boost::type_erasure;
+namespace mpl = boost::mpl;
+
+int main()
+{
+    any<copy_constructible<>, _self> x(make_binding<::mpl::map<mpl::pair<_self, char> > >());
+}

--- a/test/fail_default_construct_from_binding_of.cpp
+++ b/test/fail_default_construct_from_binding_of.cpp
@@ -1,0 +1,25 @@
+// Boost.TypeErasure library
+//
+// Copyright 2011 Steven Watanabe
+//
+// Distributed under the Boost Software License Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// $Id$
+
+#include <boost/type_erasure/any.hpp>
+#include <boost/type_erasure/binding.hpp>
+#include <boost/type_erasure/binding_of.hpp>
+#include <boost/type_erasure/builtin.hpp>
+#include <boost/mpl/map.hpp>
+#include <boost/mpl/pair.hpp>
+
+using namespace boost::type_erasure;
+namespace mpl = boost::mpl;
+
+int main()
+{
+    any<copy_constructible<>, _self> x(1, make_binding<mpl::map<mpl::pair<_self, int> > >());
+    any<copy_constructible<>, _self> y(binding_of(x));
+}

--- a/test/test_binding_of.cpp
+++ b/test/test_binding_of.cpp
@@ -38,3 +38,14 @@ BOOST_AUTO_TEST_CASE(test_binding_of)
         >());
     BOOST_CHECK(b == expected);
 }
+
+BOOST_AUTO_TEST_CASE(test_construction_with_binding_of)
+{
+    typedef ::boost::mpl::vector<
+        common<>,
+        constructible<_self()>,
+        relaxed
+    > test_concept;
+    any<test_concept> x(2);
+    BOOST_CHECK_NO_THROW(any<test_concept> y(binding_of(x)));
+}


### PR DESCRIPTION
Constructing an any from a static_binding resulted in the wrong overload being chosen (when rvalue-references are supported).
This pull-request fixes that.

Additionally, some compile- and unit-tests regarding `binding` and `binding_of` were added and extended.

The associated trac-ticket is: [12292](https://svn.boost.org/trac/boost/ticket/12292)
