### PR TITLE
Disable C++11 code path in dynamic_vtable.hpp

### DIFF
--- a/include/boost/type_erasure/detail/dynamic_vtable.hpp
+++ b/include/boost/type_erasure/detail/dynamic_vtable.hpp
@@ -29,7 +29,7 @@ namespace boost {
 namespace type_erasure {
 namespace detail {
 
-#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_CONSTEXPR) && !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_CONSTEXPR) && !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)  && !BOOST_WORKAROUND(BOOST_MSVC, <= 1900)
 
 template<class P>
 struct dynamic_binding_impl


### PR DESCRIPTION
Without this there are test failures for dynamic_any_cast.
Previously this path was disabled by virtue of BOOST_NO_CXX11_CONSTEXPR, but since constexpr works just fine in VC14up3 this path now gets enabled.  The failure has nothing to do with constexpr support though.
