### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,22 +5,24 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/fusion//boost_fusion
+    /boost/iterator//boost_iterator
+    /boost/mp11//boost_mp11
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/thread//boost_thread
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/typeof//boost_typeof
+    /boost/vmd//boost_vmd ;
+
 project /boost/type_erasure
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/fusion//boost_fusion
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mp11//boost_mp11
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/thread//boost_thread
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/typeof//boost_typeof
-        <library>/boost/vmd//boost_vmd
         <include>include
     ;
 
@@ -32,3 +34,4 @@ explicit
 call-if : boost-library type_erasure
     : install boost_type_erasure
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/type_erasure
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -21,8 +21,6 @@ constant boost_dependencies :
     /boost/vmd//boost_vmd ;
 
 project /boost/type_erasure
-    : common-requirements
-        <include>include
     ;
 
 explicit

--- a/build.jam
+++ b/build.jam
@@ -7,20 +7,20 @@ import project ;
 
 project /boost/type_erasure
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/fusion//boost_fusion
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mp11//boost_mp11
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/thread//boost_thread
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
-        <source>/boost/vmd//boost_vmd
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/fusion//boost_fusion
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mp11//boost_mp11
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/thread//boost_thread
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
+        <library>/boost/vmd//boost_vmd
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,34 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/type_erasure
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/fusion//boost_fusion
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mp11//boost_mp11
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/thread//boost_thread
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <source>/boost/vmd//boost_vmd
+        <include>include
+    ;
+
+explicit
+    [ alias boost_type_erasure : build//boost_type_erasure ]
+    [ alias all : boost_type_erasure example test ]
+    ;
+
+call-if : boost-library type_erasure
+    : install boost_type_erasure
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/type_erasure

--- a/build.jam
+++ b/build.jam
@@ -15,7 +15,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
-    /boost/thread//boost_thread
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits
     /boost/typeof//boost_typeof

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,7 +12,7 @@ constant boost_dependencies_private :
 
 project
   : source-location ../src
-  : common-requirements <library>$(boost_dependencies)
+  : common-requirements <include>../include <library>$(boost_dependencies)
   : requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
     <library>$(boost_dependencies_private)
   : usage-requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,6 +8,7 @@
 
 project
   : source-location ../src
+  : common-requirements <library>$(boost_dependencies)
   : requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
   : usage-requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
     <define>BOOST_TYPE_ERASURE_NO_LIB=1

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -10,6 +10,7 @@ project
   : source-location ../src
   : requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
   : usage-requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
+    <define>BOOST_TYPE_ERASURE_NO_LIB=1
 ;
 
 lib boost_type_erasure : dynamic_binding.cpp /boost/thread//boost_thread ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,12 +6,10 @@
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-project /boost/type_erasure
+project
   : source-location ../src
   : requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
   : usage-requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
 ;
 
-lib boost_type_erasure : dynamic_binding.cpp /boost//thread ;
-
-boost-install boost_type_erasure ;
+lib boost_type_erasure : dynamic_binding.cpp /boost/thread//boost_thread ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,10 +6,15 @@
 # accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+constant boost_dependencies_private :
+    /boost/thread//boost_thread
+    ;
+
 project
   : source-location ../src
   : common-requirements <library>$(boost_dependencies)
   : requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
+    <library>$(boost_dependencies_private)
   : usage-requirements <link>shared:<define>BOOST_TYPE_ERASURE_DYN_LINK
     <define>BOOST_TYPE_ERASURE_NO_LIB=1
 ;

--- a/doc/Jamfile.jam
+++ b/doc/Jamfile.jam
@@ -26,7 +26,7 @@ xml type_erasure : type_erasure.qbk : <dependency>reference ;
 
 doxygen reference
   :
-    [ glob ../../../boost/type_erasure/*.hpp ]
+    [ glob ../include/boost/type_erasure/*.hpp ]
   :
     <doxygen:param>EXPAND_ONLY_PREDEF=YES
     <doxygen:param>"ALIASES= \\

--- a/example/Jamfile.jam
+++ b/example/Jamfile.jam
@@ -21,4 +21,4 @@ compile associated.cpp ;
 
 run print_sequence.cpp ;
 run printf.cpp ;
-run multifunction.cpp ;
+run multifunction.cpp /boost/variant//boost_variant /boost/phoenix//boost_phoenix ;

--- a/example/Jamfile.jam
+++ b/example/Jamfile.jam
@@ -8,6 +8,8 @@
 
 import testing ;
 
+project : requirements <library>/boost/type_erasure//boost_type_erasure ;
+
 compile basic.cpp ;
 compile multi.cpp ;
 compile convert.cpp ;

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -7,42 +7,42 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
-import ../../../libs/config/checks/config ;
+import checks/config ;
 
-run test_binding.cpp /boost//unit_test_framework ;
-run test_increment.cpp /boost//unit_test_framework ;
-run test_add.cpp /boost//unit_test_framework ;
-run test_add_assign.cpp /boost//unit_test_framework ;
-run test_callable.cpp /boost//unit_test_framework ;
-run test_reference.cpp /boost//unit_test_framework ;
-run test_construct.cpp /boost//unit_test_framework ;
-run test_relaxed.cpp /boost//unit_test_framework ;
-run test_assign.cpp /boost//unit_test_framework : : :
+run test_binding.cpp /boost/test//unit_test_framework ;
+run test_increment.cpp /boost/test//unit_test_framework ;
+run test_add.cpp /boost/test//unit_test_framework ;
+run test_add_assign.cpp /boost/test//unit_test_framework ;
+run test_callable.cpp /boost/test//unit_test_framework ;
+run test_reference.cpp /boost/test//unit_test_framework ;
+run test_construct.cpp /boost/test//unit_test_framework ;
+run test_relaxed.cpp /boost/test//unit_test_framework ;
+run test_assign.cpp /boost/test//unit_test_framework : : :
   <toolset>gcc,<target-os>windows:<cxxflags>-Wa,-mbig-obj
   <toolset>gcc,<target-os>windows,<variant>debug:<build>no
   ;
-run test_construct_ref.cpp /boost//unit_test_framework ;
-run test_construct_cref.cpp /boost//unit_test_framework ;
-run test_any_cast.cpp /boost//unit_test_framework ;
-run test_binding_of.cpp /boost//unit_test_framework ;
-run test_typeid_of.cpp /boost//unit_test_framework ;
-run test_nested.cpp /boost//unit_test_framework ;
-run test_less.cpp /boost//unit_test_framework ;
-run test_equal.cpp /boost//unit_test_framework ;
-run test_negate.cpp /boost//unit_test_framework ;
-run test_dereference.cpp /boost//unit_test_framework ;
-run test_subscript.cpp /boost//unit_test_framework ;
-run test_forward_iterator.cpp /boost//unit_test_framework ;
-run test_tuple.cpp /boost//unit_test_framework ;
-run test_stream.cpp /boost//unit_test_framework ;
-run test_deduced.cpp /boost//unit_test_framework ;
-run test_same_type.cpp /boost//unit_test_framework ;
-run test_member.cpp /boost//unit_test_framework ;
-run test_null.cpp /boost//unit_test_framework ;
-run test_free.cpp /boost//unit_test_framework ;
-run test_is_empty.cpp /boost//unit_test_framework ;
-run test_dynamic_any_cast.cpp /boost//unit_test_framework /boost//type_erasure ;
-run test_limits.cpp /boost//unit_test_framework
+run test_construct_ref.cpp /boost/test//unit_test_framework ;
+run test_construct_cref.cpp /boost/test//unit_test_framework ;
+run test_any_cast.cpp /boost/test//unit_test_framework ;
+run test_binding_of.cpp /boost/test//unit_test_framework ;
+run test_typeid_of.cpp /boost/test//unit_test_framework ;
+run test_nested.cpp /boost/test//unit_test_framework ;
+run test_less.cpp /boost/test//unit_test_framework ;
+run test_equal.cpp /boost/test//unit_test_framework ;
+run test_negate.cpp /boost/test//unit_test_framework ;
+run test_dereference.cpp /boost/test//unit_test_framework ;
+run test_subscript.cpp /boost/test//unit_test_framework ;
+run test_forward_iterator.cpp /boost/test//unit_test_framework ;
+run test_tuple.cpp /boost/test//unit_test_framework ;
+run test_stream.cpp /boost/test//unit_test_framework ;
+run test_deduced.cpp /boost/test//unit_test_framework ;
+run test_same_type.cpp /boost/test//unit_test_framework ;
+run test_member.cpp /boost/test//unit_test_framework ;
+run test_null.cpp /boost/test//unit_test_framework ;
+run test_free.cpp /boost/test//unit_test_framework ;
+run test_is_empty.cpp /boost/test//unit_test_framework ;
+run test_dynamic_any_cast.cpp /boost/test//unit_test_framework /boost/type_erasure//boost_type_erasure ;
+run test_limits.cpp /boost/test//unit_test_framework
   : requirements
     [ config.requires cxx11_rvalue_references
                       cxx11_template_aliases

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -7,7 +7,10 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
-import checks/config ;
+import-search /boost/config/checks ;
+import config ;
+
+project : requirements <library>/boost/type_erasure//boost_type_erasure ;
 
 run test_binding.cpp /boost/test//boost_unit_test_framework ;
 run test_increment.cpp /boost/test//boost_unit_test_framework ;

--- a/test/Jamfile.jam
+++ b/test/Jamfile.jam
@@ -9,40 +9,40 @@
 import testing ;
 import checks/config ;
 
-run test_binding.cpp /boost/test//unit_test_framework ;
-run test_increment.cpp /boost/test//unit_test_framework ;
-run test_add.cpp /boost/test//unit_test_framework ;
-run test_add_assign.cpp /boost/test//unit_test_framework ;
-run test_callable.cpp /boost/test//unit_test_framework ;
-run test_reference.cpp /boost/test//unit_test_framework ;
-run test_construct.cpp /boost/test//unit_test_framework ;
-run test_relaxed.cpp /boost/test//unit_test_framework ;
-run test_assign.cpp /boost/test//unit_test_framework : : :
+run test_binding.cpp /boost/test//boost_unit_test_framework ;
+run test_increment.cpp /boost/test//boost_unit_test_framework ;
+run test_add.cpp /boost/test//boost_unit_test_framework ;
+run test_add_assign.cpp /boost/test//boost_unit_test_framework ;
+run test_callable.cpp /boost/test//boost_unit_test_framework ;
+run test_reference.cpp /boost/test//boost_unit_test_framework ;
+run test_construct.cpp /boost/test//boost_unit_test_framework ;
+run test_relaxed.cpp /boost/test//boost_unit_test_framework ;
+run test_assign.cpp /boost/test//boost_unit_test_framework : : :
   <toolset>gcc,<target-os>windows:<cxxflags>-Wa,-mbig-obj
   <toolset>gcc,<target-os>windows,<variant>debug:<build>no
   ;
-run test_construct_ref.cpp /boost/test//unit_test_framework ;
-run test_construct_cref.cpp /boost/test//unit_test_framework ;
-run test_any_cast.cpp /boost/test//unit_test_framework ;
-run test_binding_of.cpp /boost/test//unit_test_framework ;
-run test_typeid_of.cpp /boost/test//unit_test_framework ;
-run test_nested.cpp /boost/test//unit_test_framework ;
-run test_less.cpp /boost/test//unit_test_framework ;
-run test_equal.cpp /boost/test//unit_test_framework ;
-run test_negate.cpp /boost/test//unit_test_framework ;
-run test_dereference.cpp /boost/test//unit_test_framework ;
-run test_subscript.cpp /boost/test//unit_test_framework ;
-run test_forward_iterator.cpp /boost/test//unit_test_framework ;
-run test_tuple.cpp /boost/test//unit_test_framework ;
-run test_stream.cpp /boost/test//unit_test_framework ;
-run test_deduced.cpp /boost/test//unit_test_framework ;
-run test_same_type.cpp /boost/test//unit_test_framework ;
-run test_member.cpp /boost/test//unit_test_framework ;
-run test_null.cpp /boost/test//unit_test_framework ;
-run test_free.cpp /boost/test//unit_test_framework ;
-run test_is_empty.cpp /boost/test//unit_test_framework ;
-run test_dynamic_any_cast.cpp /boost/test//unit_test_framework /boost/type_erasure//boost_type_erasure ;
-run test_limits.cpp /boost/test//unit_test_framework
+run test_construct_ref.cpp /boost/test//boost_unit_test_framework ;
+run test_construct_cref.cpp /boost/test//boost_unit_test_framework ;
+run test_any_cast.cpp /boost/test//boost_unit_test_framework ;
+run test_binding_of.cpp /boost/test//boost_unit_test_framework ;
+run test_typeid_of.cpp /boost/test//boost_unit_test_framework ;
+run test_nested.cpp /boost/test//boost_unit_test_framework ;
+run test_less.cpp /boost/test//boost_unit_test_framework ;
+run test_equal.cpp /boost/test//boost_unit_test_framework ;
+run test_negate.cpp /boost/test//boost_unit_test_framework ;
+run test_dereference.cpp /boost/test//boost_unit_test_framework ;
+run test_subscript.cpp /boost/test//boost_unit_test_framework ;
+run test_forward_iterator.cpp /boost/test//boost_unit_test_framework ;
+run test_tuple.cpp /boost/test//boost_unit_test_framework ;
+run test_stream.cpp /boost/test//boost_unit_test_framework ;
+run test_deduced.cpp /boost/test//boost_unit_test_framework ;
+run test_same_type.cpp /boost/test//boost_unit_test_framework ;
+run test_member.cpp /boost/test//boost_unit_test_framework ;
+run test_null.cpp /boost/test//boost_unit_test_framework ;
+run test_free.cpp /boost/test//boost_unit_test_framework ;
+run test_is_empty.cpp /boost/test//boost_unit_test_framework ;
+run test_dynamic_any_cast.cpp /boost/test//boost_unit_test_framework /boost/type_erasure//boost_type_erasure ;
+run test_limits.cpp /boost/test//boost_unit_test_framework
   : requirements
     [ config.requires cxx11_rvalue_references
                       cxx11_template_aliases


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.